### PR TITLE
Small fixes for Win32

### DIFF
--- a/memory_mapped_file.cpp
+++ b/memory_mapped_file.cpp
@@ -97,7 +97,7 @@ namespace memory_mapped_file
         if (! pathname) return;
         if (is_open()) close();
     #if defined(_WIN32)
-        file_handle_ = ::CreateFile(pathname, GENERIC_READ,
+        file_handle_ = ::CreateFileA(pathname, GENERIC_READ,
             FILE_SHARE_READ | FILE_SHARE_WRITE, 0,
             OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, 0);
         if (file_handle_ == INVALID_HANDLE_VALUE) return;
@@ -173,7 +173,7 @@ namespace memory_mapped_file
             else return;
         }
 
-        file_handle_ = ::CreateFile(pathname, GENERIC_READ | GENERIC_WRITE,
+        file_handle_ = ::CreateFileA(pathname, GENERIC_READ | GENERIC_WRITE,
             FILE_SHARE_READ | FILE_SHARE_WRITE, 0,
             win_open_mode, FILE_ATTRIBUTE_NORMAL, 0);
         if (file_handle_ == INVALID_HANDLE_VALUE) return;


### PR DESCRIPTION
This patch does the following changes:
1.
`CreateFile` is a macro defined in `WinBase.h`:
```cpp
#ifdef UNICODE
#define CreateFile  CreateFileW
#else
#define CreateFile  CreateFileA
#endif // !UNICODE
```
When `UNICODE` is defined, `CreateFile` is an alias of `CreateFileW`(The type of the first parameter of `CreateFileW` is `const wchar_t *`). And a compilation error will raises.

Since `open` accepts the file name of type `const char *`, I think we can use `CreateFileA` instead.

2.
When `CreateFileMapping` failed, it returns a `NULL` instead of `INVALID_HANDLE_VALUE`.

3.
I found that `CreateFileMapping` returns NULL in `read_only_mmf::map` on a 32-bit compiler(in which case `size_t` is `unsigned int`). So code below:
```cpp
        file_mapping_handle_ = ::CreateFileMapping(
            file_handle_, 0, PAGE_READONLY, (offset + mapping_size) >> 32,
(offset + mapping_size) & 0xFFFFFFFF, 0);
```
will not work as purposed on a 32-bit compiler. I did a little test here: [rshift_test.cpp](https://github.com/myd7349/Ongoing-Study/blob/master/cpp/Basics/rshift_test.cpp).

In my test of `read_only_mmf`, `CreateFileMappling` will return `NULL`, and `GetLastError` returns `ERROR_NOT_ENOUGH_MEMORY`.

According to [Creating a File Mapping Object](https://docs.microsoft.com/en-us/windows/desktop/Memory/creating-a-file-mapping-object):
>When you do not want the size of the file to change (for example, when mapping read-only files), call CreateFileMapping and specify zero for both dwMaximumSizeHigh and dwMaximumSizeLow. Doing this creates a file mapping object that is exactly the same size as the file.

So passing two `0` will fix this issue.

4.
Fix several warnings.